### PR TITLE
Fix memory leak in request.py

### DIFF
--- a/tezosetl/rpc/request.py
+++ b/tezosetl/rpc/request.py
@@ -21,10 +21,10 @@ def make_post_request(endpoint_uri, data, *args, **kwargs):
     return response.content
 
 
-def make_get_request(endpoint_uri, *args, **kwargs):
+def make_get_request(url, path, *args, **kwargs):
     kwargs.setdefault('timeout', 10)
-    session = _get_session(endpoint_uri)
-    response = session.get(endpoint_uri, *args, **kwargs)
+    session = _get_session(url)
+    response = session.get(url + path, *args, **kwargs)
     response.raise_for_status()
 
     return response.content

--- a/tezosetl/rpc/tezos_rpc.py
+++ b/tezosetl/rpc/tezos_rpc.py
@@ -34,7 +34,8 @@ class TezosRpc:
 
     def get(self, endpoint):
         raw_response = make_get_request(
-            self.provider_uri + endpoint,
+            self.provider_uri,
+            endpoint,
             timeout=self.timeout
         )
 


### PR DESCRIPTION
The session cache used full url as a key, which resulted in unlimited cache growth. Fixed by using the url without the path used as a key.