### PR TITLE
Add register_global_constant operations

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -285,6 +285,30 @@ proposals: STRING (REPEATED)
 period: INTEGER
 ```
 
+### register_global_constant_operations
+
+```
+level: INTEGER
+timestamp: TIMESTAMP
+block_hash: STRING
+branch: STRING
+signature: STRING
+operation_hash: STRING
+operation_group_index: INTEGER
+operation_index: INTEGER
+content_index: INTEGER
+internal_operation_index: INTEGER
+source: STRING
+fee: INTEGER
+counter: INTEGER
+gas_limit: INTEGER
+storage_limit: INTEGER
+value: STRING
+status: STRING
+consumed_gas: INTEGER
+storage_size: INTEGER
+global_address: STRING
+```
 ### reveal_operations
 
 ```

--- a/tezosetl/enums/operation_kinds.py
+++ b/tezosetl/enums/operation_kinds.py
@@ -10,6 +10,7 @@ class OperationKind:
     endorsement_with_slot = 'endorsement_with_slot'
     origination = 'origination'
     proposals = 'proposals'
+    register_global_constant = 'register_global_constant'
     reveal = 'reveal'
     seed_nonce_revelation = 'seed_nonce_revelation'
     set_deposits_limit = 'set_deposits_limit'
@@ -27,6 +28,7 @@ class OperationKind:
         endorsement_with_slot,
         origination,
         proposals,
+        register_global_constant,
         reveal,
         seed_nonce_revelation,
         set_deposits_limit,

--- a/tezosetl/mappers/operation_mapper.py
+++ b/tezosetl/mappers/operation_mapper.py
@@ -98,7 +98,9 @@ def map_operation(operation_kind, content, base_operation):
     elif operation_kind == OperationKind.set_deposits_limit:
         return map_set_deposits_limit(content, base_operation)
     elif operation_kind == OperationKind.ballot:
-        return map_ballot(content, base_operation)
+        return map_ballot(content, base_operation)    
+    elif operation_kind == OperationKind.register_global_constant:
+        return map_register_global_constant(content, base_operation)
     else:
         raise KeyError(f'Operation kind {operation_kind} not recognized. {json.dumps(content)}')
 
@@ -170,6 +172,22 @@ def map_delegation(content, base_operation):
         'status': operation_result.get('status'),
     }}
 
+def map_register_global_constant(content, base_operation):
+    operation_result = get_operation_result(content)
+
+    return {**base_operation, **{
+        'source': content.get('source'),
+        'destination': content.get('destination'),
+        'fee': safe_int(content.get('fee')),
+        'amount': safe_int(content.get('amount')),
+        'counter': safe_int(content.get('counter')),
+        'gas_limit': safe_int(content.get('gas_limit')),
+        'storage_limit': safe_int(content.get('storage_limit')),
+        'status': operation_result.get('status'),
+        'consumed_gas': safe_int(operation_result.get('consumed_gas')),
+        'storage_size': safe_int(operation_result.get('storage_size')),
+        'value': json_dumps(operation.get('value')),
+    }}
 
 def map_reveal(content, base_operation):
     operation_result = get_operation_result(content)


### PR DESCRIPTION
Add `register_global_constant` operation, a rare operation added in late 2021 that has only occurred twice but resulted in two missing days that could not be synced.

https://www.marigold.dev/post/introducing-global-constants